### PR TITLE
Hotfix: Shops crashing

### DIFF
--- a/data/monster.json
+++ b/data/monster.json
@@ -37,7 +37,7 @@
     },
     "sheep": {
         "name": "Sheep",
-        "exp": 3,
+        "exp": 8,
         "money": 5,
         "base_stats": {
             "strength": 4,
@@ -77,7 +77,7 @@
     },
     "wolf": {
         "name": "Wolf",
-        "exp": 5,
+        "exp": 10,
         "money": 3,
         "base_stats": {
             "strength": 9,
@@ -113,7 +113,7 @@
     },
     "bird": {
         "name": "Bird",
-        "exp": 4,
+        "exp": 9,
         "money": 8,
         "base_stats": {
             "strength": 5,
@@ -149,7 +149,7 @@
     },
     "sheepSheep_boss": {
         "name": "Sheep Sheep",
-        "exp": 20,
+        "exp": 30,
         "money": 50,
         "base_stats": {
             "strength": 15,
@@ -193,7 +193,7 @@
     },
     "slime": {
         "name": "Basic Slime",
-        "exp": 4,
+        "exp": 9,
         "money": 9,
         "base_stats": {
             "strength": 4,
@@ -234,7 +234,7 @@
     },
     "blue_slime": {
         "name": "Blue Slime",
-        "exp": 6,
+        "exp": 10,
         "money": 12,
         "base_stats": {
             "strength": 5,
@@ -274,7 +274,7 @@
     },
     "red_slime": {
         "name": "Red Slime",
-        "exp": 7,
+        "exp": 12,
         "money": 15,
         "base_stats": {
             "strength": 12,
@@ -314,7 +314,7 @@
     },
     "king_slime": {
         "name": "King Slime",
-        "exp": 15,
+        "exp": 55,
         "money": 50,
         "base_stats": {
             "strength": 15,
@@ -364,7 +364,7 @@
     },
     "shadow_rat": {
         "name": "Shadow Rat",
-        "exp": 9,
+        "exp": 19,
         "money": 8,
         "base_stats": {
             "strength": 13,
@@ -408,7 +408,7 @@
     },
     "fallen_knight": {
         "name": "Fallen Knight",
-        "exp": 12,
+        "exp": 22,
         "money": 15,
         "base_stats": {
             "strength": 18,
@@ -471,7 +471,7 @@
     },
     "fallen_archer": {
         "name": "Fallen Archer",
-        "exp": 12,
+        "exp": 22,
         "money": 15,
         "base_stats": {
             "strength": 14,
@@ -534,7 +534,7 @@
     },
     "lost_soul": {
         "name": "Lost Soul of the Warfield",
-        "exp": 25,
+        "exp": 55,
         "money": 100,
         "base_stats": {
             "strength": 25,

--- a/data/zones.json
+++ b/data/zones.json
@@ -4,7 +4,7 @@
         "description": "A quiet place with only slimes roaming around. It's a good place to train your abilities.",
         "color": [144, 238, 144],
         "required": {
-            "level": 5,
+            "level": 4,
             "quests": null,
             "items": []  
         },
@@ -27,7 +27,7 @@
             },
             "group5": {
                 "m-names": ["king_slime"],
-                "spawn-chance": "10000000000000000000000",
+                "spawn-chance": "1",
                 "min_level": 10
             }
         },
@@ -52,7 +52,7 @@
             },
             "group3": {
                 "m-names": ["bird", "sheep"],
-                "spawn-chance": "200"
+                "spawn-chance": "2"
             },
             "group4": {
                 "m-names": ["bird", "slime"],

--- a/utils/messageTemplateUtils.js
+++ b/utils/messageTemplateUtils.js
@@ -91,7 +91,7 @@ exports.generateShopSelector = async function(message) {
 		});
 	}
 
-	const row = new ActionRowBuilder()
+	var row = new ActionRowBuilder()
 		.addComponents(
 			new StringSelectMenuBuilder()
 				.setCustomId('shopChoice-' + message.author.id)
@@ -100,6 +100,14 @@ exports.generateShopSelector = async function(message) {
 					list
 				),
 		);
+
+	if(list.length == 0) {
+		var row = new EmbedBuilder() 
+			.setColor(0x1be118)
+			.setTitle('No shop available')	
+			.setDescription('There is no shop available in this zone !');
+	}
+				
 
 	return message.reply({content: 'Choose the shop you want to visit !', components: [row] });
 }

--- a/utils/messageTemplateUtils.js
+++ b/utils/messageTemplateUtils.js
@@ -101,11 +101,15 @@ exports.generateShopSelector = async function(message) {
 				),
 		);
 
+	console.log(list.length);
+
 	if(list.length == 0) {
 		var row = new EmbedBuilder() 
 			.setColor(0x1be118)
 			.setTitle('No shop available')	
 			.setDescription('There is no shop available in this zone !');
+
+		return message.reply({content: 'Choose the shop you want to visit !', embeds: [row] });
 	}
 				
 


### PR DESCRIPTION
Shops were crashing if there were none in the current zone. The fix should prevent the player for asking for a stringSelectMenu when there is none.